### PR TITLE
skip test for Windows machines

### DIFF
--- a/t/02-lock.t
+++ b/t/02-lock.t
@@ -18,6 +18,9 @@ use Time::HiRes ();
 
 use File::SharedNFSLock;
 
+plan skip_all => "threads don't behave nicely on Windows" 
+    if $Config{osname} =~ /win/i;
+
 my $some_file = 'some_file_on_nfs';
 my $lock_file = 'some_file_on_nfs.lock';
 


### PR DESCRIPTION
These tests seem to be very hit and miss with Windows. Skipping them altogether (TODOing them might also an alternative).
